### PR TITLE
Fix comp_eq function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,7 +284,7 @@ macro_rules! define_secret_unsigned_integer {
             pub fn comp_eq(self, rhs: Self) -> Self {
                 let a = self;
                 let b = rhs;
-                let x = a | b;
+                let x = a ^ b;
                 let minus_x = -x;
                 let x_or_minus_x = x | minus_x;
                 let xnx = x_or_minus_x >> ($bits - 1);
@@ -458,3 +458,46 @@ define_signed_unsigned_casting!(U64, u64, I64, i64);
 define_signed_unsigned_casting!(U32, u32, I32, i32);
 define_signed_unsigned_casting!(U16, u16, I16, i16);
 define_signed_unsigned_casting!(U8, u8, I8, i8);
+
+macro_rules! define_tests {
+    ($modname:ident, $type:ident) => {
+        #[cfg(test)]
+        mod $modname {
+            use crate::*;
+
+            #[test]
+            fn test_comp_eq_ok() {
+                let a = $type::from(3);
+                let b = $type::from(3);
+                let eq = $type::comp_eq(a, b);
+                assert_eq!(eq.declassify(), $type::ones().declassify());
+            }
+
+            #[test]
+            fn test_comp_eq_fail() {
+                let a = $type::from(3);
+                let b = $type::from(42);
+                let eq = $type::comp_eq(a, b);
+                assert_eq!(eq.declassify(), $type::zero().declassify());
+            }
+
+            #[test]
+            fn test_comp_neq_ok() {
+                let a = $type::from(3);
+                let b = $type::from(42);
+                let eq = $type::comp_ne(a, b);
+                assert_eq!(eq.declassify(), $type::ones().declassify());
+            }
+
+            #[test]
+            fn test_comp_neq_fail() {
+                let a = $type::from(3);
+                let b = $type::from(3);
+                let eq = $type::comp_ne(a, b);
+                assert_eq!(eq.declassify(), $type::zero().declassify());
+            }
+        }
+    };
+}
+
+define_tests!(tests_u8, U8);


### PR DESCRIPTION
The `comp_eq` function was wrong, this PR fixes
the implementation and adds tests for `comp_eq` and `comp_ne`.
Apart from these, the other functions should also be tested!

This pull request resolves issue #1.